### PR TITLE
削除機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -23,9 +23,7 @@ class PrototypesController < ApplicationController
   end
 
   def destroy
-    if @prototype.user_id == current_user.id
       @prototype.destroy
-    end
   end
   private
 

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -22,6 +22,12 @@ class PrototypesController < ApplicationController
   def show
   end
 
+  def destroy
+    prototype = Prototype.find(params[:id])
+    if prototype.user_id == current_user.id
+      prototype.destroy
+    end
+  end
   private
 
   def set_prototype

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,5 @@
 class PrototypesController < ApplicationController
-  before_action :set_prototype, only: :show
+  before_action :set_prototype, only: [:show, :destroy]
 
   def index
     @prototypes = Prototype.all

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -23,9 +23,8 @@ class PrototypesController < ApplicationController
   end
 
   def destroy
-    prototype = Prototype.find(params[:id])
-    if prototype.user_id == current_user.id
-      prototype.destroy
+    if @prototype.user_id == current_user.id
+      @prototype.destroy
     end
   end
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+
+  def current_user_has?(instance)
+    user_signed_in? && @prototype.user_id == current_user.id
+  end
+
 end

--- a/app/views/prototypes/destroy.html.haml
+++ b/app/views/prototypes/destroy.html.haml
@@ -1,0 +1,11 @@
+.container.proto-page
+  %header.row.user-nav
+    .col-md-6
+      .media
+  .row
+    .col-md-9.image-box
+      '削除しました'
+      / = image_tag(@prototype.set_main_thumbnail.large, class: 'img-responsive img-size-fix', style: "margin: 0 auto;")
+  .row.proto-description
+    .btn.btn-primary.navbar-btn
+      = link_to 'Topへ戻る', root_path

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -13,10 +13,6 @@
       = link_to "VIEW TAGS", "#", class: "btn btn-default col-lg-1"
 
 .container.proto-list
-  .btn.btn-primary.navbar-btn
-    削除
-    = link_to '削除', "/prototypes/#{prototype.id}", method: :delete
-
   .row
     = render partial: 'prototypes/prototype', collection: @prototypes
 

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -13,6 +13,10 @@
       = link_to "VIEW TAGS", "#", class: "btn btn-default col-lg-1"
 
 .container.proto-list
+  .btn.btn-primary.navbar-btn
+    削除
+    = link_to '削除', "/prototypes/#{prototype.id}", method: :delete
+
   .row
     = render partial: 'prototypes/prototype', collection: @prototypes
 

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -14,6 +14,8 @@
             .degree
               = @prototype.user.position
   .row
+    .btn.btn-primary.navbar-btn
+      = link_to '削除', "/prototypes/#{@prototype.id}", method: :delete
     .col-md-9.image-box
       = image_tag(@prototype.set_main_thumbnail.large, class: 'img-responsive img-size-fix', style: "margin: 0 auto;")
     .col-md-3

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -14,8 +14,9 @@
             .degree
               = @prototype.user.position
   .row
-    .btn.btn-primary.navbar-btn
-      = link_to '削除', "/prototypes/#{@prototype.id}", method: :delete
+    - if current_user_has?(@prototype)
+      .btn.btn-primary.navbar-btn
+        = link_to '削除', "/prototypes/#{@prototype.id}", method: :delete
     .col-md-9.image-box
       = image_tag(@prototype.set_main_thumbnail.large, class: 'img-responsive img-size-fix', style: "margin: 0 auto;")
     .col-md-3

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root 'prototypes#index'
 
-  resources :prototypes, only: [:index, :new, :create, :show]
+  resources :prototypes, only: [:index, :new, :create, :show, :destroy]
   resources :users, only: [:show, :edit, :update]
 end


### PR DESCRIPTION
#WHAT
コンテンツの削除機能

#WHY
必須機能なので。

「・ログインしていないユーザの時
　・投稿ユーザとは異なるユーザの時」
は削除ボタンが非表示になるようにしました。
条件処理はヘルパーメソッドに切り出したので他の場面でも使えるかと思います。
app/helpers/application_helper.rb #3
```
current_user_has?(instance)
```


![](https://i.gyazo.com/d339fba6cb386901eaa378b215e74387.png)


![](https://i.gyazo.com/d068f0b63a52d065cf5f01479450f28f.png)

上記画像二枚。ユーザ名の違いでボタン表示が変化していることを確認ください。