### PR TITLE
EDITボタンを編集。

### DIFF
--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -8,9 +8,8 @@
         .media-body
           %h4#top-aligned-media.media-heading
             = @prototype.title
-            .btn.btn-xs.navbar-inverse.btn-edit
-              = link_to "EDIT", edit_prototype_path(@prototype)
-              / 馬場園のヘルパーメソッドを後で使って、current_userのものにしか表示されないようにする
+            -if current_user_has?(@prototype)
+              = link_to "EDIT", edit_prototype_path(@prototype), class: "btn btn-xs navbar-inverse btn-edit"
           .proto-user
             by
             = link_to "#{@prototype.user.name}", user_path(@prototype.user)


### PR DESCRIPTION
#WHAT
ユーザーがログインしていない時にはEDITボタンをビューから消す。
EditボタンのEDITという字だけにリンクが貼ってあるのでボタン全体にリンクをつける。

#WHY
必須の機能なため。

![edit button link](https://user-images.githubusercontent.com/37580358/39425517-d045873e-4cb6-11e8-89e4-553c5f02e2d4.gif)
![default](https://user-images.githubusercontent.com/37580358/39425518-d06ed53a-4cb6-11e8-9497-1c793e9addd3.png)
![default](https://user-images.githubusercontent.com/37580358/39425520-d099274a-4cb6-11e8-9598-f1d7dad54ec8.png)